### PR TITLE
WIP: fixes for OpenGL 2.1

### DIFF
--- a/src/GLInit.jl
+++ b/src/GLInit.jl
@@ -25,10 +25,10 @@ function createcontextinfo(dict)
 	if length(glsl) >= 2
 		glsl = VersionNumber(int(glsl[1]), int(glsl[2])) 
 		if glsl.major == 1 && glsl.minor <= 2
-			error("OpenGL shading Language version too low. Try updating graphic driver!")
+			warn("OpenGL Shading Language (GLSL) version $glsl may be too low. Consider updating your graphics driver.")
 		end
 		GLSL_VERSION = string(glsl.major) * rpad(string(glsl.minor),2,"0")
-		if glsl.major >= 1 
+		if glsl.major >= 1 && glsl.minor > 20
 			GLSL_VARYING_QUALIFIER = "in"
 		else
 			GLSL_VARYING_QUALIFIER = "varying"
@@ -39,9 +39,9 @@ function createcontextinfo(dict)
 
 	glv = split(bytestring(glGetString(GL_VERSION)), ['.', ' '])
 	if length(glv) >= 2
-		glv = VersionNumber(int(glv[1]), int(glv[2])) 
+		glv = VersionNumber(int(glv[1]), int(glv[2]))
 		if glv.major < 3
-			error("OpenGL version too low. Try updating graphic driver!")
+			warn("OpenGL version $glv may be too low. Consider updating your graphics driver.")
 		end
 	else
 		error("Unexpected version number string. Please report this bug! Version string: $(glsl)")

--- a/src/GLTexture.jl
+++ b/src/GLTexture.jl
@@ -1,5 +1,4 @@
-import Images.imread
-import Images.Image
+import Images: imread, colorspace, Image
 export Texture, texturetype, update!
 
 #Supported datatypes
@@ -142,7 +141,7 @@ function Texture(
         img = imread(img)
     end
     @assert length(img.data) > 0
-    imgFormat   = img.properties["colorspace"]
+    imgFormat   = colorspace(img)
     if imgFormat == "ARGB"
         tmp = img.data[1,1:end, 1:end]
         img.data[1,1:end, 1:end] = img.data[2,1:end, 1:end]


### PR DESCRIPTION
I've come to the conclusion that I should make some effort to get this running on my laptop (or get a better laptop :smile:). The "Images" commit is probably something you want anyway, the second I'm far less sure about. I basically know nothing about OpenGL, though I'm hoping to change that.

This has gotten me past a couple of errors. Where I'm stymied now is this error:
```C
#version 120

uniform vec4 bg_color;
uniform vec4 grid_color;
uniform vec3 grid_thickness;
uniform vec3 gridsteps;

varying vec3 vposition;

varying vec4 fragment_color;
#define M_PI 3.1415926535897932384626433832795
void main()
{
        vec3  v                 = vec3(vposition.xyz) * gridsteps * M_PI;
    vec3  f             = abs(cos(v));
    vec3  df            = fwidth(v);
    vec3  g             = smoothstep(vec3(1.0) - vec3(0.01), vec3(1.0), f) * df;
    float c             = max(g.x, max(g.y, g.z))*10;
    fragment_color      = mix(bg_color, vec4(vposition, 0.2), c);
}
ERROR: /home/tim/.julia/v0.4/GLPlot/src/shader/grid.frag
0:19(5): error: assignment to read-only variable 'fragment_color'
```
It seems like the [fix is to use `gl_FragColor`](http://stackoverflow.com/questions/24737705/opengl-shader-builder-errors-on-compiling). Am I on the right track? Is this likely to eventually result in success, and if so are you interested in supporting this? Or, is this just the first step along a great uglification of your beautiful, modern OpenGL packages? If the latter, I should just get a newer laptop.