### PR TITLE
imgFormat == "RGBA" is missing.

### DIFF
--- a/src/GLTexture.jl
+++ b/src/GLTexture.jl
@@ -172,7 +172,7 @@ function Texture(
         img.data[3,1:end, 1:end] = img.data[4,1:end, 1:end]
         img.data[4,1:end, 1:end] = tmp
         imgdata  = img.data
-    elseif imgFormat == "Gray" || imgFormat == "RGB" || imgFormat == "BGRA" || imgFormat == "RGB4"
+    elseif imgFormat == "Gray" || imgFormat == "RGB" || imgFormat == "RGBA" || imgFormat == "BGRA" || imgFormat == "RGB4"
         imgdata = img.data
     else
         error("Color Format $(imgFormat) not supported")


### PR DESCRIPTION
Packages: GLPlot (0.0.3), Images (0.4.13), GLAbstraction (0.0.3)
When I try to run "image.jl" which is an example of GLPlot package, an error messages shows that "Color Format RGBA not supported".
