### PR TITLE
Add debug

### DIFF
--- a/src/GLCamera.jl
+++ b/src/GLCamera.jl
@@ -1,11 +1,11 @@
 abstract Camera{T}
-immutable OrthographicCamera{T} <: Camera{T}
+type OrthographicCamera{T} <: Camera{T}
 	window_size::Signal{Vector4{Int}}
 	view::Signal{Matrix4x4{T}}
 	projection::Signal{Matrix4x4{T}}
 	projectionview::Signal{Matrix4x4{T}}
 end
-immutable PerspectiveCamera{T} <: Camera{T}
+type PerspectiveCamera{T} <: Camera{T}
 	pivot::Signal{Pivot{T}}
 	window_size::Signal{Vector4{Int}}
 	nearclip::Signal{T}

--- a/src/GLRender.jl
+++ b/src/GLRender.jl
@@ -1,9 +1,69 @@
+#==
+   Make debugging interface flexible (hopefully the compile step will remove
+   dead code when not optimizing. Higher level values mean more intrusive
+   (may render app unusable  if too much output is generated)
+       Level (ORed bit values)
+             1 : add traceback for constructors and related
+             4 : print uniforms
+             8 : print vertices
+            16 : reserved for GLTypes.GLVertexArray
+            32 : reserved for postRenderFunctions
+==#
+debugFlagOn = isdefined(:GLRenderDebugLevel)
+debugLevel  = debugFlagOn ? GLRenderDebugLevel : 0
 
+#==  Set the debug parameters; if this function is not used, GLRenderDebugLevel
+     must be set at time of package loading.
+==#
+function setDebugLevels(flagOn::Bool,level::Int)
+    global debugFlagOn
+    global debugLevel
+    debugFlagOn = flagOn
+    debugLevel  = flagOn ? level : 0
+end
+
+function debugRenderUnif(program,renderobject)
+       debugLevel & 4 == 0 && return
+       id = program.id
+       println("In debugRenderUnif program.id=$id")
+       for (key,value) in program.uniformloc
+           if haskey(renderobject.uniforms, key)
+               tv=typeof(value)
+               tu=typeof(renderobject.uniforms[key])
+               println("\t$key corresponds to value with type=$tv")
+               println("\t   and renderobject.uniform[$key] with type=$tu")
+           else
+               println("\t key $key not found in  renderobject")
+           end
+       end
+end
+
+function debugRenderVertex(va::GLVertexArray,  mode::GLenum=GL_TRIANGLES)
+       debugLevel & 8 == 0 && return
+       ln  = va.length
+       iln = va.indexlength
+       id =  va.id
+       println("In debugVertex mode=$mode, \tGLVertexArray.id=$id,\tlength=$ln,\tindexlength=$iln")
+end
+
+
+function debugPostRenderFn(fn,args...)
+    debugLevel & 32 == 0 && return
+    fntyp = typeof(fn)
+    
+    println("In debugPostRenderFn\t$fntyp\t$fn" )
+    println("   args=$args")
+    println("++++ end debugPostRenderFn output ++++\n")
+end
+                
+############  end of debugging section ############
+       
 function render(list::AbstractVector)
     for elem in list
         render(elem)
     end
 end
+
 
 function render(renderobject::RenderObject, vertexarray=renderobject.vertexarray)
     for elem in renderobject.prerenderfunctions
@@ -11,15 +71,24 @@ function render(renderobject::RenderObject, vertexarray=renderobject.vertexarray
     end
     program = vertexarray.program
     glUseProgram(program.id)
+
+    debugFlagOn && debugRenderUnif(program,renderobject) ## debug
+
     for (key,value) in program.uniformloc
         haskey(renderobject.uniforms, key) && gluniform(value..., renderobject.uniforms[key])
     end
     for elem in renderobject.postrenderfunctions
+
+        debugFlagOn && debugPostRenderFn(elem[1],elem[2]...) ## debug
+        # apply elem[1]
         elem[1](elem[2]...)
     end
 end
 
+
 function render(vao::GLVertexArray, mode::GLenum=GL_TRIANGLES)
+    debugFlagOn && debugRenderVertex(vao, mode)         ## debug
+
     glBindVertexArray(vao.id)
     if vao.indexlength > 0
         glDrawElements(mode, vao.indexlength, GL_UNSIGNED_INT, GL_NONE)

--- a/src/GLTypes.jl
+++ b/src/GLTypes.jl
@@ -167,7 +167,7 @@ type GLVertexArray
         glBindBuffer(buffer.buffertype, buffer.id)
         attribLocation = get_attribute_location(program.id, attribute)
 
-        glVertexAttribPointer(attribLocation,  cardinality(buffer), GL_FLOAT, GL_FALSE, 0, C_NULL)
+        glVertexAttribPointer(attribLocation,  cardinality(buffer), GL_FLOAT, GL_FALSE, 0, 0)
         glEnableVertexAttribArray(attribLocation)
       end
     end
@@ -329,8 +329,9 @@ function    debugGLVertexAConstruct(bufferDict::Dict{Symbol, GLBuffer},
         v=kv[2]
         println("\tkey=$k\tvalue type:", typeof(v))
     end
-   if debugLevel & 1
+   if debugLevel & 1 != 0
        println("Traceback for debugGLVertexAConstruct")
        Base.show_backtrace(STDOUT, backtrace())
+       println("")
    end
 end

--- a/src/GLTypes.jl
+++ b/src/GLTypes.jl
@@ -144,6 +144,8 @@ type GLVertexArray
 
   function GLVertexArray(bufferDict::Dict{Symbol, GLBuffer}, program::GLProgram)
     @assert !isempty(bufferDict)
+    debugFlagOn && debugGLVertexAConstruct(bufferDict, program)
+
     #get the size of the first array, to assert later, that all have the same size
     indexSize = -1
     _length = -1
@@ -220,7 +222,7 @@ function Base.show(io::IO, obj::RenderObject)
         println(io, "   ", name, "\n      ", uniform)
     end
     println(io, "vertexarray length: ", obj.vertexarray.length)
-    println(io, "vertexarray indexlength: ", obj.vertexarray.indexlength)
+    println(io, "vertexarray indexlength: ", obj.vertexarray.indexlength)    
 end
 RenderObject{T}(data::Dict{Symbol, T}, program::GLProgram) = RenderObject(Dict{Symbol, Any}(data), program)
 
@@ -311,3 +313,24 @@ end
 Style(x::Symbol) = Style{x}()
 Style() = Style{:Default}()
 mergedefault!{S}(style::Style{S}, styles, customdata) = merge!(copy(styles[S]), Dict{Symbol, Any}(customdata))
+
+
+#==
+   Debugging, see conventions in GLRender.jl
+==#
+
+function    debugGLVertexAConstruct(bufferDict::Dict{Symbol, GLBuffer},
+                                    program::GLProgram)
+    debugLevel & 16 == 0 && return
+    id = program.id
+    println("In debugGLVertexAConstruct program.id=$id")
+    map (bufferDict)   do kv
+        k=kv[1]
+        v=kv[2]
+        println("\tkey=$k\tvalue type:", typeof(v))
+    end
+   if debugLevel & 1
+       println("Traceback for debugGLVertexAConstruct")
+       Base.show_backtrace(STDOUT, backtrace())
+   end
+end


### PR DESCRIPTION
Hi,
the proposed changes permit the user to select debug information printout. I made a similar
pull request in GLWindow. *Only tested in Julia 0.4.*

1) selection is performed by 
<CODE>function setDebugLevels(flagOn::Bool,level::Int)</CODE>
2)Level (ORed bit values)
<TABLE>
<TR>     <TD>       1  <TD> add traceback for constructors and related
<TR>      <TD>         4 <TD>  print uniforms
<TR>       <TD>        8  <TD> print vertices
<TR>        <TD>     16  <TD> used  for GLTypes.GLVertexArray
<TR>         <TD>    32  <TD> used for postRenderFunctions
</TABLE>

Additional selection of the IO stream for debug output could be added. Will keep a separate addDebug branch for improvements (based for now on my own usage.