### PR TITLE
Further changes for Reactive API, normalize conflict

### DIFF
--- a/src/GLCamera.jl
+++ b/src/GLCamera.jl
@@ -128,7 +128,7 @@ function OrthographicCamera{T}(
 	projection = lift(orthographicprojection, windows_size, nearclip, farclip) 
 	#projection = Input(eye(Mat4))
 	#view = Input(eye(Mat4))
-	projectionview = lift(*, Matrix4x4{T}, projection, view)
+	projectionview = lift(*, projection, view)
 
 	OrthographicCamera{T}(
 							windows_size,
@@ -335,7 +335,7 @@ function PerspectiveCamera{T <: Real}(
 	view 			= lift(lookat,  positionvec, lookatvec1, up)
 	w 				= lift(getindex, window_size, Input(3))
 	h 				= lift(last, window_size)
-	window_ratio 	= lift(/, T, w, h)
+	window_ratio 	= lift(/, w, h,typ=T)
 	projection 		= lift(perspectiveprojection, fov, window_ratio, nearclip, farclip)
 
 	projectionview 	= lift(*,  projection, view)

--- a/src/GLMatrixMath.jl
+++ b/src/GLMatrixMath.jl
@@ -143,9 +143,9 @@ end
 
 function lookat{T}(eyePos::Vector3{T}, lookAt::Vector3{T}, up::Vector3{T})
 
-    zaxis  = normalize(eyePos - lookAt)
-    xaxis  = normalize(cross(up, zaxis))
-    yaxis  = normalize(cross(zaxis, xaxis))
+    zaxis  = FixedSizeArrays.normalize(eyePos - lookAt)
+    xaxis  = FixedSizeArrays.normalize(cross(up, zaxis))
+    yaxis  = FixedSizeArrays.normalize(cross(zaxis, xaxis))
 
     viewMatrix = eye(T, 4,4)
     viewMatrix[1, 1:3] = [xaxis...]


### PR DESCRIPTION
Hi,

Changed 
* 1) lift call for new Reactive API, 
* 2) added qualification to normalize call because of conflict diagnosed as follows:
"Warning: using FixedSizeArrays.normalize in module GLAbstraction conflicts with an existing identifier."

I guess that you probably have a better way to handle the `normalize` part