### PR TITLE
warn on optimized out or name mismatch instead of errors

### DIFF
--- a/src/GLExtendedFunctions.jl
+++ b/src/GLExtendedFunctions.jl
@@ -28,7 +28,7 @@ get_attribute_location(program::GLuint, name::Symbol) = get_attribute_location(p
 function get_attribute_location(program::GLuint, name::String)
     const location::GLint = glGetAttribLocation(program, name)
     if location == -1
-        error(
+        warn(
             "Named attribute (:$(name)) is not an active attribute in the specified program object or\n
             the name starts with the reserved prefix gl_\n"
         )

--- a/src/GLTypes.jl
+++ b/src/GLTypes.jl
@@ -221,6 +221,7 @@ function GLVertexArray(bufferdict::Dict, program::GLProgram)
             )
             bind(buffer)
             attribLocation = get_attribute_location(program.id, attribute)
+            (attribLocation == -1) && continue
             glVertexAttribPointer(attribLocation, cardinality(buffer), julia2glenum(eltype(buffer)), GL_FALSE, 0, C_NULL)
             glEnableVertexAttribArray(attribLocation)
             buffers[attribute] = buffer


### PR DESCRIPTION
Fixes issue in GLVisualize where do to compiler optimizations 
vertex attributes get optimized out on some systems , causing GLVisualize to errors