### PR TITLE
Improve typing for translate_cam and add tests

### DIFF
--- a/src/GLCamera.jl
+++ b/src/GLCamera.jl
@@ -392,12 +392,16 @@ function imagespace(pos, camera)
     Point2f0(pos[1], pos[2]) / pos[4]
 end
 
-
-
 function translate_cam(
-        translate, proj, view, window_size, prj_type,
-        eyepos_s, lookat_s, up_s,
-    )
+        translate::T,
+        proj::Mat4{Float32},
+        view::Mat4{Float32},
+        window_size::SimpleRectangle{Int},
+        prj_type::Projection,
+        eyepos_s::T,
+        lookat_s::T,
+        up_s::T,
+    ) where T<:Vec3
     translate == Vec3f0(0) && return nothing # nothing to do
 
     lookat, eyepos, up, prjt = map(value, (lookat_s, eyepos_s, up_s, prj_type))
@@ -480,9 +484,8 @@ function PerspectiveCamera(
     projectionview = map(*, projectionmatrix, viewmatrix)
 
     preserve(map(translate_cam,
-       trans, Signal(projectionmatrix), Signal(viewmatrix), Signal(window_size),
-       Signal(projectiontype),  Signal(eyeposition), Signal(lookatposition),
-       Signal(upvector)
+       trans, projectionmatrix, viewmatrix, window_size,
+       projectiontype,  eyeposition, lookatposition, upvector
     ))
 
     preserve(map(theta) do theta_v

--- a/src/GLCamera.jl
+++ b/src/GLCamera.jl
@@ -394,13 +394,13 @@ end
 
 function translate_cam(
         translate::T,
-        proj::Mat4{Float32},
-        view::Mat4{Float32},
-        window_size::SimpleRectangle{Int},
-        prj_type::Projection,
-        eyepos_s::T,
-        lookat_s::T,
-        up_s::T,
+        proj::Signal{Mat4{Float32}},
+        view::Signal{Mat4{Float32}},
+        window_size::Signal{SimpleRectangle{Int}},
+        prj_type::Signal{Projection},
+        eyepos_s::Signal{T},
+        lookat_s::Signal{T},
+        up_s::Signal{T},
     ) where T<:Vec3
     translate == Vec3f0(0) && return nothing # nothing to do
 
@@ -484,8 +484,9 @@ function PerspectiveCamera(
     projectionview = map(*, projectionmatrix, viewmatrix)
 
     preserve(map(translate_cam,
-       trans, projectionmatrix, viewmatrix, window_size,
-       projectiontype,  eyeposition, lookatposition, upvector
+       trans, Signal(projectionmatrix), Signal(viewmatrix), Signal(window_size),
+       Signal(projectiontype),  Signal(eyeposition), Signal(lookatposition),
+       Signal(upvector)
     ))
 
     preserve(map(theta) do theta_v

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using GLAbstraction, GeometryTypes, ModernGL, FileIO, GLWindow
 using ColorTypes
 using Base.Test
 import GLAbstraction: N0f8
+import Reactive: Signal
 
 
 
@@ -57,5 +58,32 @@ while isopen(window) && i < 20
     i += 1
 end
 GLFW.DestroyWindow(window)
+
+# test for type stability in translate_cam
+translate = Vec3f0([1.0, 1.0, 1.0])
+proj = Signal(Mat4{Float32}(eye(Float32,4)))
+view_test = Signal(Mat4{Float32}(eye(Float32,4)))
+window_size = Signal(SimpleRectangle(-1, -1, 1, 1)) #from DummyCamera
+prj_type = Signal(PERSPECTIVE)
+eyepos_s = Signal(Vec3f0([1.0, 0.0, 0.0]))
+lookat_s = Signal(Vec3f0([0.0, 1.0, 0.0]))
+up_s = Signal(Vec3f0([0.0, 0.0, 1.0]))
+# Record original types
+type_eyepos = typeof(eyepos_s)
+type_lookat = typeof(lookat_s)
+
+GLAbstraction.translate_cam(
+    translate,
+    proj,
+    view_test,
+    window_size,
+    prj_type,
+    eyepos_s,
+    lookat_s,
+    up_s
+)
+
+@test typeof(eyepos_s)==type_eyepos
+@test typeof(lookat_s)==type_lookat
 
 end


### PR DESCRIPTION
Added explicit typing for `translate_cam` inputs and added tests to ensure that `push!`ed variables in `translate_cam` retain their original types.