### PR TITLE
Make shader string literals return Shaders

### DIFF
--- a/src/shader/shader.jl
+++ b/src/shader/shader.jl
@@ -65,22 +65,22 @@ end
 # Different shader string literals- usage: e.g. frag" my shader code"
 macro frag_str(source::AbstractString)
     quote
-        (GL_FRAGMENT_SHADER, $source)
+        Shader(GL_FRAGMENT_SHADER, $source)
     end
 end
 macro vert_str(source::AbstractString)
     quote
-        (GL_VERTEX_SHADER, $source)
+        Shader(GL_VERTEX_SHADER, $source)
     end
 end
 macro geom_str(source::AbstractString)
     quote
-        (GL_GEOMETRY_SHADER, $source)
+        Shader(GL_GEOMETRY_SHADER, $source)
     end
 end
 macro comp_str(source::AbstractString)
     quote
-        (GL_COMPUTE_SHADER, $source)
+        Shader(GL_COMPUTE_SHADER, $source)
     end
 end
 


### PR DESCRIPTION
Run into the triangle example failing because shader string literals return tuples and `Program` expects shaders. This fixes it by making the string literals return `Shader`s, which I think makes more sense, and it seems [it used to be that way](https://github.com/JuliaGL/GLAbstraction.jl/pull/66/files#diff-3bcb8e0187346ed182ce51b41e01ee9efda0b7a6185333bb199eb1878fba4798L4). The change could break existing programs if they are using shader string literals.